### PR TITLE
chore: add tagpr release and label automation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,23 @@
+"type: feature":
+  - head-branch:
+      - "(^|.*/)(feat|feature)[/_-]"
+
+"type: bug":
+  - head-branch:
+      - "(^|.*/)(bug|bugfix|fix|hotfix)[/_-]"
+
+"type: docs":
+  - head-branch:
+      - "(^|.*/)(doc|docs)[/_-]"
+
+"type: performance":
+  - head-branch:
+      - "(^|.*/)(perf|performance)[/_-]"
+
+"type: compatibility":
+  - head-branch:
+      - "(^|.*/)(compat|compatibility)[/_-]"
+
+"type: maintenance":
+  - head-branch:
+      - "(^|.*/)(chore|ci|deps|maintenance|refactor|test|tooling)[/_-]"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - tagpr

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,3 +2,28 @@ changelog:
   exclude:
     labels:
       - tagpr
+  categories:
+    - title: "💥 Breaking Changes"
+      labels:
+        - "breaking-change"
+    - title: "🚀 Features"
+      labels:
+        - "type: feature"
+    - title: "🐛 Bug Fixes"
+      labels:
+        - "type: bug"
+    - title: "📚 Documentation"
+      labels:
+        - "type: docs"
+    - title: "⚡ Performance"
+      labels:
+        - "type: performance"
+    - title: "🔁 Compatibility"
+      labels:
+        - "type: compatibility"
+    - title: "🔧 Maintenance"
+      labels:
+        - "type: maintenance"
+    - title: "Other Changes"
+      labels:
+        - "*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,20 @@
+name: labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v6
+        with:
+          sync-labels: true

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,0 +1,20 @@
+name: tagpr
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  tagpr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: Songmu/tagpr@555e72cee68c09d43dc2337dc9ba890955b630da # v1.19.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,7 @@
+[tagpr]
+    releaseBranch = main
+    versionFile = -
+    vPrefix = true
+    changelog = true
+    release = true
+    fixedMajorVersion = 1


### PR DESCRIPTION
## Summary

- Add tagpr configuration and workflow for release PR/tag automation
- Configure release changelog categories based on existing GitHub labels
- Add actions/labeler configuration to apply `type:` labels from PR branch names