### PR TITLE
Integrate tagpr with goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,14 @@
 name: release
 on:
-  push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish, for example v1.2.3"
+        required: true
+        type: string
+
+permissions:
+  contents: write
 
 env:
   GOPATH: ${{ github.workspace }}
@@ -15,15 +21,31 @@ jobs:
         working-directory: ${{ env.WORKSPACE }}
     runs-on: ubuntu-latest
     steps:
+      - name: Validate tag input
+        working-directory: ${{ github.workspace }}
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::tag must match vX.Y.Z"
+            exit 1
+          fi
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          fetch-depth: 1
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
           path: ${{ env.WORKSPACE }}
+      - name: Verify checked out tag
+        env:
+          TAG: ${{ inputs.tag }}
+        run: test "$(git describe --tags --exact-match)" = "$TAG"
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25
+          go-version-file: ${{ env.WORKSPACE }}/go.mod
+          cache: true
+          cache-dependency-path: ${{ env.WORKSPACE }}/go.sum
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -11,10 +11,43 @@ jobs:
       contents: write
       pull-requests: write
       issues: read
+    outputs:
+      tag: ${{ steps.tagpr.outputs.tag }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: Songmu/tagpr@555e72cee68c09d43dc2337dc9ba890955b630da # v1.19.0
+      - id: tagpr
+        uses: Songmu/tagpr@555e72cee68c09d43dc2337dc9ba890955b630da # v1.19.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  goreleaser:
+    needs: tagpr
+    if: needs.tagpr.outputs.tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.tagpr.outputs.tag }}
+          fetch-depth: 0
+      - name: Verify checked out tag
+        env:
+          TAG: ${{ needs.tagpr.outputs.tag }}
+        run: test "$(git describe --tags --exact-match)" = "$TAG"
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Integrate GoReleaser execution into the tagpr workflow.
- Convert the existing release workflow into a manual fallback.
- Add tag checkout and validation for both automatic and manual releases.

## Background / Motivation
tagpr-created tags do not reliably trigger a separate tag-push release workflow when using `GITHUB_TOKEN`, so GoReleaser should run in the same workflow after tagpr creates a release tag.

## Changes
- `.github/workflows/tagpr.yml`
  - Exposes tagpr's `tag` output.
  - Runs GoReleaser only when tagpr creates a tag.
  - Checks out and verifies the exact tag before publishing assets.

- `.github/workflows/release.yml`
  - Replaces tag-push trigger with `workflow_dispatch`.
  - Adds required `tag` input and `vX.Y.Z` validation.
 