### PR TITLE
feat: support named primitive types

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ struct: `time.Time` and structures you defined
 
 `time.Time` values are encoded and decoded as UTC by default. Location information is not preserved; values with a non-UTC location round-trip as the same instant in UTC.
 
+named types: types whose underlying type is a supported primitive are supported, including chained definitions and aliases
+
+```go
+type DefinedInt int               // defined type
+type ChainedDefinedInt DefinedInt // chained definition
+type AliasInt = int               // alias
+```
+
+They can also be used as slice/array/map elements (e.g. `[]DefinedInt`, `map[DefinedInt]AliasInt`).
+A named primitive type defined in another package must be exported to be referenced.
+
 ### Tags
 
 Renaming or omitting are available.
@@ -172,6 +183,9 @@ type Example struct {
 
     // because bytes.Buffer is in outside package
     Buf bytes.Buffer
+
+    // because an unexported named primitive type in another package is inaccessible
+    Hidden b.hiddenInt
 }
 
 func (e Example) F() {

--- a/def_a.go
+++ b/def_a.go
@@ -183,6 +183,26 @@ func (p *private) SetInt() {
 	p.i = 1
 }
 
+type definedInt int
+type chainedDefinedInt definedInt
+type aliasInt = int
+type definedByte byte
+
+type testingNamedPrimitive struct {
+	Defined       definedInt
+	Chained       chainedDefinedInt
+	Alias         aliasInt
+	Pointer       *definedInt
+	Slice         []definedInt
+	Bytes         []definedByte
+	Array         [2]definedInt
+	Map           map[definedInt]aliasInt
+	Nested        map[aliasInt][]chainedDefinedInt
+	Imported      define2.DefinedInt
+	ImportedSlice []define2.DefinedInt
+	ImportedMap   map[define2.DefinedInt]define2.AliasInt
+}
+
 type notGenerated1 struct {
 	Int       int
 	Interface any
@@ -223,9 +243,4 @@ type notGenerated7 struct {
 type notGenerated8 struct {
 	Child bytes.Buffer
 	Int   int
-}
-
-type notGeneratedInt int
-type notGenerated10 struct {
-	Int notGeneratedInt
 }

--- a/internal/fortest/define/define.go
+++ b/internal/fortest/define/define.go
@@ -5,10 +5,26 @@ import (
 	. "time"
 )
 
+// DefinedInt is a primitive-compatible defined type for test.
+type DefinedInt int
+
+// ChainedDefinedInt is a primitive-compatible defined type chain for test.
+type ChainedDefinedInt DefinedInt
+
+// AliasInt is a primitive-compatible alias type for test.
+type AliasInt = int
+
+type hiddenInt int
+
 // A is a definition for test
 type A struct {
-	Int int
-	B   define2.B
+	Int     int
+	B       define2.B
+	Defined DefinedInt
+	Chained ChainedDefinedInt
+	Alias   AliasInt
+	Slice   []DefinedInt
+	Map     map[DefinedInt]AliasInt
 }
 
 // AA is a definition for test
@@ -19,4 +35,9 @@ type AA struct {
 // NotGeneratedChild is a definition for test
 type NotGeneratedChild struct {
 	Interface any
+}
+
+// NotGeneratedNamedPrimitive uses an inaccessible named primitive for test.
+type NotGeneratedNamedPrimitive struct {
+	Hidden hiddenInt
 }

--- a/internal/generator/analyze.go
+++ b/internal/generator/analyze.go
@@ -17,6 +17,12 @@ import (
 	"github.com/shamaton/msgpackgen/internal/generator/structure"
 )
 
+type primitiveTypeInfo struct {
+	PrimitiveName string
+	ImportPath    string
+	NoUseQual     bool
+}
+
 func (g *generator) getPackages(files []string) error {
 
 	for _, file := range files {
@@ -97,7 +103,75 @@ func (g *generator) analyze() error {
 		}
 	}
 
+	g.createPrimitiveTypeMap()
 	return g.setFieldToStructs()
+}
+
+func (g *generator) createPrimitiveTypeMap() {
+	for importPath, parseFiles := range g.importPath2ParseFiles {
+		typeExprs := map[string]ast.Expr{}
+		for _, parseFile := range parseFiles {
+			for _, decl := range parseFile.Decls {
+				genDecl, ok := decl.(*ast.GenDecl)
+				if !ok || genDecl.Tok != token.TYPE {
+					continue
+				}
+				for _, spec := range genDecl.Specs {
+					typeSpec, ok := spec.(*ast.TypeSpec)
+					if !ok {
+						continue
+					}
+					if _, ok := typeSpec.Type.(*ast.StructType); ok {
+						continue
+					}
+					typeExprs[typeSpec.Name.Name] = typeSpec.Type
+				}
+			}
+		}
+
+		noUseQual := g.noUserQualMap[importPath]
+
+		primitiveTypes := map[string]primitiveTypeInfo{}
+		resolvedTypes := map[string]primitiveTypeInfo{}
+		var resolve func(string, map[string]bool) (primitiveTypeInfo, bool)
+		resolve = func(name string, seen map[string]bool) (primitiveTypeInfo, bool) {
+			if structure.IsPrimitive(name) {
+				return primitiveTypeInfo{PrimitiveName: name}, true
+			}
+			if info, ok := resolvedTypes[name]; ok {
+				return info, true
+			}
+			if seen[name] {
+				return primitiveTypeInfo{}, false
+			}
+			seen[name] = true
+
+			expr, ok := typeExprs[name]
+			if !ok {
+				return primitiveTypeInfo{}, false
+			}
+			ident, ok := expr.(*ast.Ident)
+			if !ok {
+				return primitiveTypeInfo{}, false
+			}
+			info, ok := resolve(ident.Name, seen)
+			if !ok {
+				return primitiveTypeInfo{}, false
+			}
+			info.ImportPath = importPath
+			info.NoUseQual = noUseQual
+			resolvedTypes[name] = info
+			if importPath == g.outputImportPath || ast.IsExported(name) {
+				primitiveTypes[name] = info
+			}
+			return info, true
+		}
+
+		for name := range typeExprs {
+			resolve(name, map[string]bool{})
+		}
+		g.importPath2PrimitiveTypes[importPath] = primitiveTypes
+	}
 }
 
 func (g *generator) createAnalyzedStructs(parseFile *ast.File, packageName, importPath string, analyzedMap map[*ast.File]bool) error {
@@ -219,7 +293,8 @@ func (g *generator) setFieldToStructs() error {
 			}
 		}
 
-		err := g.setFieldToStruct(analyzedStruct, importMap, dotStructs, sameHierarchyStructs)
+		primitiveTypes := g.importPath2PrimitiveTypes[analyzedStruct.ImportPath]
+		err := g.setFieldToStruct(analyzedStruct, importMap, dotStructs, sameHierarchyStructs, primitiveTypes)
 		if err != nil {
 			return err
 		}
@@ -229,6 +304,7 @@ func (g *generator) setFieldToStructs() error {
 
 func (g *generator) setFieldToStruct(target *structure.Structure,
 	importMap map[string]string, dotStructs map[string]*structure.Structure, sameHierarchyStructs map[string]bool,
+	primitiveTypes map[string]primitiveTypeInfo,
 ) (err error) {
 
 	analyzedFieldMap := map[string]*structure.Node{}
@@ -250,7 +326,7 @@ func (g *generator) setFieldToStruct(target *structure.Structure,
 
 				key := fmt.Sprint(i)
 
-				value, ok, rs := g.createNodeRecursive(field.Type, nil, importMap, dotStructs, sameHierarchyStructs, target.ImportPath, target.Package)
+				value, ok, rs := g.createNodeRecursive(field.Type, nil, importMap, dotStructs, sameHierarchyStructs, primitiveTypes, target.ImportPath, target.Package)
 				canGen = canGen && ok
 				if ok {
 					analyzedFieldMap[key+"@"+x.Name.String()] = value
@@ -275,6 +351,7 @@ func (g *generator) setFieldToStruct(target *structure.Structure,
 }
 func (g *generator) createNodeRecursive(expr ast.Expr, parent *structure.Node,
 	importMap map[string]string, dotStructs map[string]*structure.Structure, sameHierarchyStructs map[string]bool,
+	primitiveTypes map[string]primitiveTypeInfo,
 	importPath, packageName string) (*structure.Node, bool, []string) {
 
 	reasons := make([]string, 0)
@@ -286,6 +363,15 @@ func (g *generator) createNodeRecursive(expr ast.Expr, parent *structure.Node,
 		// time
 		if ident.Name == "Time" {
 			return structure.CreateStructNode("time", "time", ident.Name, parent), true, reasons
+		}
+		if primitiveInfo, found := primitiveTypes[ident.Name]; found {
+			return structure.CreateIdentAliasNode(
+				ident.Name,
+				primitiveInfo.PrimitiveName,
+				primitiveInfo.ImportPath,
+				primitiveInfo.NoUseQual,
+				parent,
+			), true, reasons
 		}
 		// same hierarchy struct
 		if ident.Obj != nil && ident.Obj.Kind == ast.Typ {
@@ -306,6 +392,16 @@ func (g *generator) createNodeRecursive(expr ast.Expr, parent *structure.Node,
 	// struct
 	if selector, ok := expr.(*ast.SelectorExpr); ok {
 		pkgName := fmt.Sprint(selector.X)
+		importPath := importMap[pkgName]
+		if primitiveInfo, found := g.importPath2PrimitiveTypes[importPath][selector.Sel.Name]; found {
+			return structure.CreateIdentAliasNode(
+				selector.Sel.Name,
+				primitiveInfo.PrimitiveName,
+				primitiveInfo.ImportPath,
+				primitiveInfo.NoUseQual,
+				parent,
+			), true, reasons
+		}
 		return structure.CreateStructNode(importMap[pkgName], pkgName, selector.Sel.Name, parent), true, reasons
 	}
 
@@ -329,7 +425,7 @@ func (g *generator) createNodeRecursive(expr ast.Expr, parent *structure.Node,
 			}
 			node = structure.CreateArrayNode(n.Uint64(), parent)
 		}
-		key, check, rs := g.createNodeRecursive(array.Elt, node, importMap, dotStructs, sameHierarchyStructs, importPath, packageName)
+		key, check, rs := g.createNodeRecursive(array.Elt, node, importMap, dotStructs, sameHierarchyStructs, primitiveTypes, importPath, packageName)
 		node.SetKeyNode(key)
 		reasons = append(reasons, rs...)
 		return node, check, reasons
@@ -338,8 +434,8 @@ func (g *generator) createNodeRecursive(expr ast.Expr, parent *structure.Node,
 	// map
 	if mp, ok := expr.(*ast.MapType); ok {
 		node := structure.CreateMapNode(parent)
-		key, c1, krs := g.createNodeRecursive(mp.Key, node, importMap, dotStructs, sameHierarchyStructs, importPath, packageName)
-		value, c2, vrs := g.createNodeRecursive(mp.Value, node, importMap, dotStructs, sameHierarchyStructs, importPath, packageName)
+		key, c1, krs := g.createNodeRecursive(mp.Key, node, importMap, dotStructs, sameHierarchyStructs, primitiveTypes, importPath, packageName)
+		value, c2, vrs := g.createNodeRecursive(mp.Value, node, importMap, dotStructs, sameHierarchyStructs, primitiveTypes, importPath, packageName)
 		node.SetKeyNode(key)
 		node.SetValueNode(value)
 		reasons = append(reasons, krs...)
@@ -350,7 +446,7 @@ func (g *generator) createNodeRecursive(expr ast.Expr, parent *structure.Node,
 	// *
 	if star, ok := expr.(*ast.StarExpr); ok {
 		node := structure.CreatePointerNode(parent)
-		key, check, rs := g.createNodeRecursive(star.X, node, importMap, dotStructs, sameHierarchyStructs, importPath, packageName)
+		key, check, rs := g.createNodeRecursive(star.X, node, importMap, dotStructs, sameHierarchyStructs, primitiveTypes, importPath, packageName)
 		node.SetKeyNode(key)
 		reasons = append(reasons, rs...)
 		return node, check, reasons

--- a/internal/generator/gen.go
+++ b/internal/generator/gen.go
@@ -22,13 +22,14 @@ var (
 )
 
 type generator struct {
-	fileSet               *token.FileSet
-	targetPackages        map[string]bool
-	parseFiles            []*ast.File
-	importPath2ParseFiles map[string][]*ast.File
-	parseFile2ImportPath  map[*ast.File]string
-	importPath2package    map[string]string
-	noUserQualMap         map[string]bool
+	fileSet                   *token.FileSet
+	targetPackages            map[string]bool
+	parseFiles                []*ast.File
+	importPath2ParseFiles     map[string][]*ast.File
+	parseFile2ImportPath      map[*ast.File]string
+	importPath2package        map[string]string
+	importPath2PrimitiveTypes map[string]map[string]primitiveTypeInfo
+	noUserQualMap             map[string]bool
 
 	parseFile2ImportMap    map[*ast.File]map[string]string
 	parseFile2DotImportMap map[*ast.File]map[string]*structure.Structure
@@ -90,16 +91,17 @@ func Run(inputDir, inputFile, outDir, fileName string, pointer int, useGopath, d
 	analyzedStructs = make([]*structure.Structure, 0)
 	structsInBrace = make([]string, 0)
 	g := generator{
-		useGopath:             useGopath,
-		pointer:               pointer,
-		strict:                strict,
-		verbose:               verbose,
-		targetPackages:        map[string]bool{},
-		parseFiles:            []*ast.File{},
-		importPath2package:    map[string]string{},
-		importPath2ParseFiles: map[string][]*ast.File{},
-		parseFile2ImportPath:  map[*ast.File]string{},
-		noUserQualMap:         map[string]bool{},
+		useGopath:                 useGopath,
+		pointer:                   pointer,
+		strict:                    strict,
+		verbose:                   verbose,
+		targetPackages:            map[string]bool{},
+		parseFiles:                []*ast.File{},
+		importPath2package:        map[string]string{},
+		importPath2ParseFiles:     map[string][]*ast.File{},
+		parseFile2ImportPath:      map[*ast.File]string{},
+		importPath2PrimitiveTypes: map[string]map[string]primitiveTypeInfo{},
+		noUserQualMap:             map[string]bool{},
 
 		parseFile2ImportMap:    map[*ast.File]map[string]string{},
 		parseFile2DotImportMap: map[*ast.File]map[string]*structure.Structure{},

--- a/internal/generator/structure/code_array.go
+++ b/internal/generator/structure/code_array.go
@@ -27,7 +27,7 @@ func (st *Structure) createArrayCode(node *Node, encodeFieldName, decodeFieldNam
 	if isRecursiveChildArraySliceMap(node) {
 		_, _, _, _, da, dm = st.createFieldCode(node.Elm(), encodeChildName, decodeChildName+"v")
 	}
-	isChildByte := node.Elm().IsIdentical() && node.Elm().IdenticalName == "byte"
+	isChildByte := node.Elm().IsIdentical() && node.Elm().IdenticalName == "byte" && node.Elm().AliasName == ""
 	passChildPointer := isPointerLoopElement(node.Elm())
 
 	g := arrayCodeGen{}

--- a/internal/generator/structure/code_ident.go
+++ b/internal/generator/structure/code_ident.go
@@ -17,11 +17,12 @@ func (st *Structure) createIdentCode(node *Node, encodeFieldName, decodeFieldNam
 
 	funcSuffix := g.toPascalCase(node.IdenticalName)
 
-	cArray = g.createCalcCode("Calc"+funcSuffix, Id(encodeFieldName))
-	cMap = g.createCalcCode("Calc"+funcSuffix, Id(encodeFieldName))
+	encodeValue := createIdentEncodeValue(node, encodeFieldName)
+	cArray = g.createCalcCode("Calc"+funcSuffix, encodeValue)
+	cMap = g.createCalcCode("Calc"+funcSuffix, encodeValue)
 
-	eArray = g.createEncCode("Write"+funcSuffix, Id(encodeFieldName), Id("offset"))
-	eMap = g.createEncCode("Write"+funcSuffix, Id(encodeFieldName), Id("offset"))
+	eArray = g.createEncCode("Write"+funcSuffix, encodeValue, Id("offset"))
+	eMap = g.createEncCode("Write"+funcSuffix, encodeValue, Id("offset"))
 
 	dArray = g.createDecCode(node, st.Others, decodeFieldName, "As"+funcSuffix)
 	dMap = g.createDecCode(node, st.Others, decodeFieldName, "As"+funcSuffix)
@@ -52,12 +53,24 @@ func (g identCodeGen) createDecCode(node *Node, structures []*Structure, fieldNa
 
 	codes, receiverName := createDecodeDefineVarCode(node, structures, varName)
 
-	codes = append(codes,
-		List(Id(receiverName), Id("offset"), Err()).Op("=").Id(ptn.IdDecoder).Dot(funcName).Call(Id("offset")),
-		If(Err().Op("!=").Nil()).Block(
-			Return(Lit(0), Err()),
-		),
-	)
+	if node.AliasName != "" {
+		decodedName := receiverName + "d"
+		codes = append(codes,
+			Var().Id(decodedName).Id(node.IdenticalName),
+			List(Id(decodedName), Id("offset"), Err()).Op("=").Id(ptn.IdDecoder).Dot(funcName).Call(Id("offset")),
+			If(Err().Op("!=").Nil()).Block(
+				Return(Lit(0), Err()),
+			),
+			Id(receiverName).Op("=").Add(node.AliasTypeJenChain().Call(Id(decodedName))),
+		)
+	} else {
+		codes = append(codes,
+			List(Id(receiverName), Id("offset"), Err()).Op("=").Id(ptn.IdDecoder).Dot(funcName).Call(Id("offset")),
+			If(Err().Op("!=").Nil()).Block(
+				Return(Lit(0), Err()),
+			),
+		)
+	}
 
 	codes = append(codes, createDecodeSetValueCode(node, varName, fieldName)...)
 

--- a/internal/generator/structure/code_max.go
+++ b/internal/generator/structure/code_max.go
@@ -10,7 +10,7 @@ func (st *Structure) createFieldMaxCode(node *Node, encodeFieldName string) (cAr
 	switch {
 	case node.IsIdentical():
 		funcSuffix := identCodeGen{}.toPascalCase(node.IdenticalName)
-		codes := []Code{createAddSizeMaxCode("Calc"+funcSuffix, Id(encodeFieldName))}
+		codes := []Code{createAddSizeMaxCode("Calc"+funcSuffix, createIdentEncodeValue(node, encodeFieldName))}
 		return codes, codes
 
 	case node.IsSlice():
@@ -43,7 +43,7 @@ func (st *Structure) createSliceMaxCode(node *Node, fieldName string) (cArray []
 	}
 
 	childArray, childMap := st.createFieldMaxCode(node.Elm(), childName)
-	isChildByte := node.Elm().IsIdentical() && node.Elm().IdenticalName == "byte"
+	isChildByte := node.Elm().IsIdentical() && node.Elm().IdenticalName == "byte" && node.Elm().AliasName == ""
 	passChildPointer := isPointerLoopElement(node.Elm())
 
 	cArray = createNullableSequenceMaxCode(fieldName, childName, "CalcSliceLength", isChildByte, passChildPointer, childArray)
@@ -58,7 +58,7 @@ func (st *Structure) createArrayMaxCode(node *Node, fieldName string) (cArray []
 	}
 
 	childArray, childMap := st.createFieldMaxCode(node.Elm(), childName)
-	isChildByte := node.Elm().IsIdentical() && node.Elm().IdenticalName == "byte"
+	isChildByte := node.Elm().IsIdentical() && node.Elm().IdenticalName == "byte" && node.Elm().AliasName == ""
 	passChildPointer := isPointerLoopElement(node.Elm())
 
 	cArray = createSequenceMaxCode(fieldName, childName, "CalcSliceLength", isChildByte, passChildPointer, childArray)

--- a/internal/generator/structure/code_noerr.go
+++ b/internal/generator/structure/code_noerr.go
@@ -59,7 +59,7 @@ func (st *Structure) createFieldSizeNoErrCode(node *Node, encodeFieldName string
 		if max {
 			funcName += "Max"
 		}
-		codes := []Code{createAddSizeCode(funcName, Id(encodeFieldName))}
+		codes := []Code{createAddSizeCode(funcName, createIdentEncodeValue(node, encodeFieldName))}
 		return codes, codes
 
 	case node.IsStruct():

--- a/internal/generator/structure/code_slice.go
+++ b/internal/generator/structure/code_slice.go
@@ -23,7 +23,7 @@ func (st *Structure) createSliceCode(node *Node, encodeFieldName, decodeFieldNam
 	if isRecursiveChildArraySliceMap(node) {
 		_, _, _, _, da, dm = st.createFieldCode(node.Elm(), encodeChildName, decodeChildName+"v")
 	}
-	isChildByte := node.Elm().IsIdentical() && node.Elm().IdenticalName == "byte"
+	isChildByte := node.Elm().IsIdentical() && node.Elm().IdenticalName == "byte" && node.Elm().AliasName == ""
 	passChildPointer := isPointerLoopElement(node.Elm())
 
 	g := sliceCodeGen{}

--- a/internal/generator/structure/node.go
+++ b/internal/generator/structure/node.go
@@ -22,6 +22,11 @@ type Node struct {
 
 	// for identical
 	IdenticalName string
+	AliasName     string
+
+	// for primitive-compatible named type
+	AliasImportPath string
+	AliasNoUseQual  bool
 
 	// for array
 	ArrayLen uint64
@@ -140,7 +145,11 @@ func (n Node) TypeJenChain(structures []*Structure, statements ...*Statement) *S
 
 	switch {
 	case n.IsIdentical():
-		str = str.Id(n.IdenticalName)
+		if n.AliasName != "" {
+			str = n.aliasTypeJenChain(str)
+		} else {
+			str = str.Id(n.IdenticalName)
+		}
 
 	case n.IsStruct():
 		if n.ImportPath == "time" && n.StructName == "Time" {
@@ -193,6 +202,37 @@ func CreateIdentNode(ident *ast.Ident, parent *Node) *Node {
 		fieldType:     fieldTypeIdent,
 		IdenticalName: ident.Name,
 		Parent:        parent,
+	}
+}
+
+// aliasTypeJenChain appends the named primitive type.
+func (n Node) aliasTypeJenChain(str *Statement) *Statement {
+	if n.AliasNoUseQual {
+		return str.Id(n.AliasName)
+	}
+	return str.Qual(n.AliasImportPath, n.AliasName)
+}
+
+// AliasTypeJenChain is a helper method to create alias type code.
+func (n Node) AliasTypeJenChain(statements ...*Statement) *Statement {
+	var str *Statement
+	if len(statements) > 0 {
+		str = statements[0]
+	} else {
+		str = Id("")
+	}
+	return n.aliasTypeJenChain(str)
+}
+
+// CreateIdentAliasNode creates a node of primitive-compatible named type.
+func CreateIdentAliasNode(aliasName, primitiveName, importPath string, noUseQual bool, parent *Node) *Node {
+	return &Node{
+		fieldType:       fieldTypeIdent,
+		IdenticalName:   primitiveName,
+		AliasName:       aliasName,
+		AliasImportPath: importPath,
+		AliasNoUseQual:  noUseQual,
+		Parent:          parent,
 	}
 }
 

--- a/internal/generator/structure/pattern.go
+++ b/internal/generator/structure/pattern.go
@@ -95,6 +95,13 @@ func createWriteCode(funcName string, params ...Code) Code {
 	return Id("offset").Op("=").Qual(ptn.PkEnc, funcName).Call(args...)
 }
 
+func createIdentEncodeValue(node *Node, valueName string) Code {
+	if node.AliasName != "" {
+		return Id(node.IdenticalName).Call(Id(valueName))
+	}
+	return Id(valueName)
+}
+
 func createDecodeNilCheckedCode(nonNilCodes []Code) Code {
 	return Block(
 		List(Id("isNil"), Err()).Op(":=").Id(ptn.IdDecoder).Dot("IsCodeNilChecked").Call(Id("offset")),
@@ -191,6 +198,20 @@ func createDirectSequenceDecodeCode(node *Node, childName, childIndexName, funcN
 		return nil, false
 	}
 
+	if child.AliasName != "" {
+		decodedName := childName + "d"
+		return []Code{
+			Var().Id(decodedName).Id(child.IdenticalName),
+			List(Id(decodedName), Id("offset"), Err()).
+				Op("=").
+				Id(ptn.IdDecoder).Dot(funcName).Call(Id("offset")),
+			If(Err().Op("!=").Nil()).Block(
+				Return(Lit(0), Err()),
+			),
+			Id(childName).Index(Id(childIndexName)).Op("=").Add(child.AliasTypeJenChain().Call(Id(decodedName))),
+		}, true
+	}
+
 	return []Code{
 		List(Id(childName).Index(Id(childIndexName)), Id("offset"), Err()).
 			Op("=").
@@ -211,6 +232,20 @@ func createDirectMapValueDecodeCode(node *Node, mapName, keyName string) ([]Code
 		funcName = "AsDateTime"
 	default:
 		return nil, false
+	}
+
+	if child.AliasName != "" {
+		decodedName := mapName + "d"
+		return []Code{
+			Var().Id(decodedName).Id(child.IdenticalName),
+			List(Id(decodedName), Id("offset"), Err()).
+				Op("=").
+				Id(ptn.IdDecoder).Dot(funcName).Call(Id("offset")),
+			If(Err().Op("!=").Nil()).Block(
+				Return(Lit(0), Err()),
+			),
+			Id(mapName).Index(Id(keyName)).Op("=").Add(child.AliasTypeJenChain().Call(Id(decodedName))),
+		}, true
 	}
 
 	return []Code{

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -1407,6 +1407,48 @@ func _checkValue(v any, u1, u2 any, eqs ...func() (bool, any, any)) error {
 	return nil
 }
 
+func TestNamedPrimitive(t *testing.T) {
+	defined := definedInt(rand.Intn(math.MaxInt32))
+	v := testingNamedPrimitive{
+		Defined: definedInt(rand.Intn(math.MaxInt32)),
+		Chained: chainedDefinedInt(rand.Intn(math.MaxInt32)),
+		Alias:   rand.Intn(math.MaxInt32),
+		Pointer: &defined,
+		Slice: []definedInt{
+			definedInt(rand.Intn(math.MaxInt32)),
+			definedInt(rand.Intn(math.MaxInt32)),
+		},
+		Bytes: []definedByte{1, 2, 3, 255},
+		Array: [2]definedInt{
+			definedInt(rand.Intn(math.MaxInt32)),
+			definedInt(rand.Intn(math.MaxInt32)),
+		},
+		Map: map[definedInt]aliasInt{
+			definedInt(rand.Intn(math.MaxInt32)): rand.Intn(math.MaxInt32),
+			definedInt(rand.Intn(math.MaxInt32)): rand.Intn(math.MaxInt32),
+		},
+		Nested: map[aliasInt][]chainedDefinedInt{
+			rand.Intn(math.MaxInt32): {
+				chainedDefinedInt(rand.Intn(math.MaxInt32)),
+				chainedDefinedInt(rand.Intn(math.MaxInt32)),
+			},
+		},
+		Imported: define2.DefinedInt(rand.Intn(math.MaxInt32)),
+		ImportedSlice: []define2.DefinedInt{
+			define2.DefinedInt(rand.Intn(math.MaxInt32)),
+			define2.DefinedInt(rand.Intn(math.MaxInt32)),
+		},
+		ImportedMap: map[define2.DefinedInt]define2.AliasInt{
+			define2.DefinedInt(rand.Intn(math.MaxInt32)): rand.Intn(math.MaxInt32),
+		},
+	}
+
+	var v1, v2 testingNamedPrimitive
+	if err := _checkValue(v, &v1, &v2); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestStruct(t *testing.T) {
 	check := func(v testingStruct) (testingStruct, testingStruct, error) {
 		f := func() (bool, any, any) {
@@ -1457,7 +1499,20 @@ func TestStruct(t *testing.T) {
 	}
 
 	v = testingStruct{}
-	v.A = define2.A{Int: rand.Int(), B: define.B{Int: rand.Int()}}
+	v.A = define2.A{
+		Int:     rand.Int(),
+		B:       define.B{Int: rand.Int()},
+		Defined: define2.DefinedInt(rand.Intn(math.MaxInt32)),
+		Chained: define2.ChainedDefinedInt(rand.Intn(math.MaxInt32)),
+		Alias:   rand.Intn(math.MaxInt32),
+		Slice: []define2.DefinedInt{
+			define2.DefinedInt(rand.Intn(math.MaxInt32)),
+			define2.DefinedInt(rand.Intn(math.MaxInt32)),
+		},
+		Map: map[define2.DefinedInt]define2.AliasInt{
+			define2.DefinedInt(rand.Intn(math.MaxInt32)): rand.Intn(math.MaxInt32),
+		},
+	}
 	v1, v2, err = check(v)
 	if err != nil {
 		t.Error(err)
@@ -1757,7 +1812,7 @@ func TestNotGenerated(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	err = checkUndefined(notGenerated10{}, notGenerated10{}, &notGenerated10{}, &notGenerated10{})
+	err = checkUndefined(define2.NotGeneratedNamedPrimitive{}, define2.NotGeneratedNamedPrimitive{}, &define2.NotGeneratedNamedPrimitive{}, &define2.NotGeneratedNamedPrimitive{})
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
## Issue
#11 

## Summary

- Support named types whose underlying type is a supported primitive (e.g. `type MyInt int`)
- Handle chained definitions (`type B A` where `A int`) and type aliases (`type A = int`) by recursively resolving the underlying primitive
- Allow these named types to appear as slice/array/map elements as well

## Background / Motivation

Previously the generator only recognized built-in primitive identifiers directly, so a field typed with a user-defined named primitive (a common Go idiom for type safety) was treated as unsupported and skipped. This change resolves such types to their underlying primitive and generates the appropriate conversions on encode/decode.

## Notes

- A named primitive type defined in another package must be exported to be referenced; unexported ones (e.g. `hiddenInt`) are intentionally not generated.